### PR TITLE
Fixed CMakeLists to explicitly import PkgConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,61 +2,18 @@ cmake_minimum_required(VERSION 3.14)
 set(CMAKE_CXX_STANDARD 17)
 project(TMS-Express)
 
-# Dependency: libsndfile
-# Desc: Audio IO
-# Sets: LIBSNDFILE_INCLUDE_DIR, LIBSNDFILE_LIBRARY
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(LIBSNDFILE_PKGCONF sndfile REQUIRED)
-endif(PKG_CONFIG_FOUND)
-
-find_path(LIBSNDFILE_INCLUDE_DIR
-        NAMES sndfile.hh
-        PATHS ${LIBSNDFILE_PKGCONF_INCLUDE_DIRS}
-        )
-
-find_library(LIBSNDFILE_LIBRARY
-        NAMES sndfile libsndfile-1
-        PATHS ${LIBSNDFILE_PKGCONF_LIBRARY_DIRS}
-        )
-
-include_directories(${LIBSNDFILE_INCLUDE_DIR})
-
-# Dependency: libsamplerate
-# Desc: Audio resampler
-# Sets: LIBSAMPLERATE_INCLUDE_DIR, LIBSAMPLERATE_LIBRARY
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(LIBSAMPLERATE_PKGCONF samplerate REQUIRED)
-endif(PKG_CONFIG_FOUND)
-
-find_path(LIBSAMPLERATE_INCLUDE_DIR
-        NAMES samplerate.h
-        PATHS ${LIBSAMPLERATE_PKGCONF_INCLUDE_DIRS}
-        )
-
-find_library(LIBSAMPLERATE_LIBRARY
-        NAMES samplerate libsamplerate-0
-        PATHS ${LIBSAMPLERATE_PKGCONF_LIBRARY_DIRS}
-        )
-
-include_directories(${LIBSAMPLERATE_INCLUDE_DIR})
-
-# Dependency: CLI11
-# Desc: Command-line interface library
-# Sets: CLI11
-include(FetchContent)
-FetchContent_Declare(CLI11
-        GIT_REPOSITORY "https://github.com/CLIUtils/CLI11.git"
-        GIT_TAG "v2.2.0"
-        )
-FetchContent_MakeAvailable(CLI11)
-
-# Enable unit testing if TMS_TEST is set in the environment
-if (DEFINED ENV{TMS_TEST})
-    include(test/TmsTest.cmake)
-endif()
+# Import libsndfile and libsamplerate
+include(cmake/FindSamplerate.cmake)
+include(cmake/FindCLI11.cmake)
+include(test/TmsTest.cmake)
 
 # Project files
-include_directories(inc/)
+include_directories(
+        inc/
+        ${LIBSNDFILE_INCLUDE_DIR}
+        ${LIBSAMPLERATE_INCLUDE_DIR}
+        )
+        
 add_executable(${PROJECT_NAME}
         src/Audio/AudioBuffer.cpp
         src/Audio/AudioPreprocessor.cpp
@@ -78,15 +35,20 @@ add_executable(${PROJECT_NAME}
 # Rename executable
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME tmsexpress)
 
-# Suppress depreciation warning for std::experimental::filesystem on macOS
-if (APPLE)
-    message(STATUS "Using experimental version of std::filesystem")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM)
-endif(APPLE)
-
 # Link dependencies
 target_link_libraries(${PROJECT_NAME}
         CLI11
         ${LIBSNDFILE_LIBRARY}
         ${LIBSAMPLERATE_LIBRARY}
         )
+
+# On macOS, supress warnings regarding <experimental/filesystem
+# On other systems, link the filesystem library
+if (APPLE)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM)
+else()
+    target_link_libraries(${PROJECT_NAME}
+        stdc++fs
+        )
+endif(APPLE)
+

--- a/cmake/FindCLI11.cmake
+++ b/cmake/FindCLI11.cmake
@@ -1,0 +1,19 @@
+###############################################################################
+# Project: TMS-Express
+#
+# File: FindCLI11.cmake
+#
+# Description: Imports CLI11 via GitHub
+#
+# Author: Joseph Bellahcen <joeclb@icloud.com>
+###############################################################################
+
+include(FetchContent)
+
+FetchContent_Declare(CLI11
+        GIT_REPOSITORY "https://github.com/CLIUtils/CLI11.git"
+        GIT_TAG "v2.2.0"
+        )
+        
+FetchContent_MakeAvailable(CLI11)
+

--- a/cmake/FindSamplerate.cmake
+++ b/cmake/FindSamplerate.cmake
@@ -1,0 +1,37 @@
+###############################################################################
+# Project: TMS-Express
+#
+# File: FindCLI11.cmake
+#
+# Description:   Imports libsndfile and libsamplerate via pkg-config
+#                Sets LIBSNDFILE_INCLUDE_DIR, LIBSNDFILE_LIBRARY,
+#                LIBSAMPLERATE_INCLUDE_DIR, LIBSAMPLERATE_LIBRARY
+#
+# Author: Joseph Bellahcen <joeclb@icloud.com>
+###############################################################################
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(LIBSNDFILE_PKGCONF sndfile REQUIRED)
+pkg_check_modules(LIBSAMPLERATE_PKGCONF samplerate REQUIRED)
+
+find_path(LIBSNDFILE_INCLUDE_DIR
+        NAMES sndfile.hh
+        PATHS ${LIBSNDFILE_PKGCONF_INCLUDE_DIRS}
+        )
+
+find_library(LIBSNDFILE_LIBRARY
+        NAMES sndfile libsndfile-1
+        PATHS ${LIBSNDFILE_PKGCONF_LIBRARY_DIRS}
+        )
+        
+find_path(LIBSAMPLERATE_INCLUDE_DIR
+        NAMES samplerate.h
+        PATHS ${LIBSAMPLERATE_PKGCONF_INCLUDE_DIRS}
+        )
+
+find_library(LIBSAMPLERATE_LIBRARY
+        NAMES samplerate libsamplerate-0
+        PATHS ${LIBSAMPLERATE_PKGCONF_LIBRARY_DIRS}
+        )
+

--- a/src/Interfaces/BitstreamGenerator.cpp
+++ b/src/Interfaces/BitstreamGenerator.cpp
@@ -17,17 +17,12 @@
 #include "LPC_Analysis/Autocorrelator.h"
 #include "LPC_Analysis/LinearPredictor.h"
 #include "LPC_Analysis/PitchEstimator.h"
+#include <experimental/filesystem>
 #include <fstream>
 #include <iostream>
 #include <vector>
 
-#if __APPLE__
-#include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
 
 BitstreamGenerator::BitstreamGenerator(float windowMs, int highpassHz, int lowpassHz, float preemphasis, EncoderStyle style,
                                        bool includeStopFrame, int gainShift, float maxVoicedDb, float maxUnvoicedDb, bool detectRepeats,
@@ -182,3 +177,4 @@ std::string BitstreamGenerator::formatBitstream(std::string bitstream, const std
 
     return bitstream;
 }
+

--- a/src/Interfaces/PathUtils.cpp
+++ b/src/Interfaces/PathUtils.cpp
@@ -8,17 +8,12 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "Interfaces/PathUtils.h"
+#include <experimental/filesystem>
 #include <string>
 #include <utility>
 #include <vector>
 
-#if __APPLE__
-#include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
 
 PathUtils::PathUtils(std::string filepath) {
     // Gather file metadata
@@ -102,3 +97,4 @@ std::vector<std::string> PathUtils::splitString(const std::string& str, const st
 
     return result;
 }
+

--- a/test/TmsTest.cmake
+++ b/test/TmsTest.cmake
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.14)
 set(CMAKE_CXX_STANDARD 14)
 
 include(FetchContent)
-FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+FetchContent_Declare(googletest
+        GIT_REPOSITORY "https://github.com/google/googletest.git"
+        GIT_TAG "release-1.12.1"
 )
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -29,3 +29,4 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(TMS-Test)
+


### PR DESCRIPTION
Removed macOS specific <filesystem> macros

Switched to experimental::fs on all platforms for max compatibility