### PR TITLE
Fixed double-assignment of ControlPanel signals

### DIFF
--- a/src/User_Interfaces/Control_Panels/ControlPanelLpcView.cpp
+++ b/src/User_Interfaces/Control_Panels/ControlPanelLpcView.cpp
@@ -35,9 +35,6 @@ ControlPanelLpcView::ControlPanelLpcView(QWidget *parent): ControlPanelView("LPC
 
     grid->addWidget(preemphCheckbox, row, 0);
     grid->addWidget(preemphLine, row, 1);
-
-    configureSlots();
-    reset();
 }
 
 void ControlPanelLpcView::configureSlots() {

--- a/src/User_Interfaces/Control_Panels/ControlPanelPitchView.cpp
+++ b/src/User_Interfaces/Control_Panels/ControlPanelPitchView.cpp
@@ -44,9 +44,6 @@ ControlPanelPitchView::ControlPanelPitchView(QWidget *parent): ControlPanelView(
 
     grid->addWidget(minPitchLabel, row, 0);
     grid->addWidget(minPitchLine, row, 1);
-
-    configureSlots();
-    reset();
 }
 
 void ControlPanelPitchView::configureSlots() {

--- a/src/User_Interfaces/Control_Panels/ControlPanelPostView.cpp
+++ b/src/User_Interfaces/Control_Panels/ControlPanelPostView.cpp
@@ -68,9 +68,6 @@ ControlPanelPostView::ControlPanelPostView(QWidget *parent): ControlPanelView("P
 
     grid->addWidget(maxVoicedGainLabel, row, 0);
     grid->addWidget(maxVoicedGainLine, row, 1);
-
-    configureSlots();
-    reset();
 }
 
 void ControlPanelPostView::configureSlots() {


### PR DESCRIPTION
Previously, each `ControlPanelView` initializer called its own `reset()` and `configure()` functions, but it is the job of the parent widget to call these after initialization. The result is that slots were connected twice, resulting in operations being carried out more than once