### PR TITLE
Fixed Incorrect LPC Coefficient Table Used in Synthesizer

### DIFF
--- a/src/Frame_Encoding/Synthesizer.cpp
+++ b/src/Frame_Encoding/Synthesizer.cpp
@@ -115,7 +115,7 @@ bool Synthesizer::updateSynthTable(Frame frame) {
                 synthK7 = k7[coeffs[6]];
                 synthK8 = k8[coeffs[7]];
                 synthK9 = k9[coeffs[8]];
-                synthK10 = k9[coeffs[9]];
+                synthK10 = k10[coeffs[9]];
             }
         }
     }


### PR DESCRIPTION
This PR addresses a bug in the `Synthesizer`, where the wrong coefficient table was used while updating the synthesis table