### PR TITLE
Enabled optional CLI-only build via CMake flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Joseph Bellahcen <joeclb@icloud.com>
+# Copyright (C) 2024 Joseph Bellahcen <joeclb@icloud.com>
 
 ###############################################################################
 # CMake Configuration #########################################################
@@ -10,17 +10,25 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_definitions(-Wall -Wextra -Wpedantic)
 
-# Required for Qt
-set(CMAKE_AUTOUIC ON)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-
 ###############################################################################
 # Project Configuration #######################################################
 ###############################################################################
 
 project(TMS-Express)
 option(TMSEXPRESS_BUILD_TESTS "Build test programs" ON)
+option(TMSEXPRESS_BUILD_GUI "Build GUI frontend" ON)
+
+if(TMSEXPRESS_BUILD_GUI)
+    # CMake provides the UIC, MOC, and RCC tools to aid in Qt app development
+    # - UIC: Converts .UI files to C/C++ headers
+    # - MOC: Produces "meta-object code" for Q_OBJECT classes
+    # - RCC: Embeds resource files into Qt application binary
+    set(CMAKE_AUTOUIC ON)
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTORCC ON)
+
+    add_compile_definitions(TMSEXPRESS_GUI=1)
+endif()
 
 ###############################################################################
 # Project Sources & Includes ##################################################
@@ -48,30 +56,40 @@ add_executable(${PROJECT_NAME}
     tms_express/bitstream/BitstreamGenerator.cpp
     tms_express/bitstream/PathUtils.cpp
 
-    # Frontend ###############################################################
-    tms_express/ui/cli/CommandLineApp.cpp
-
-    tms_express/ui/gui/audiowaveform/AudioWaveform.cpp
-    tms_express/ui/gui/audiowaveform/AudioWaveformView.cpp
-
-    tms_express/ui/gui/controlpanels/ControlPanelView.cpp
-    tms_express/ui/gui/controlpanels/ControlPanelPitchView.cpp
-    tms_express/ui/gui/controlpanels/ControlPanelLpcView.cpp
-    tms_express/ui/gui/controlpanels/ControlPanelPostView.cpp
-
-    tms_express/ui/gui/MainWindow.cpp
-
     # Main ####################################################################
+    tms_express/ui/cli/CommandLineApp.cpp
     tms_express/main.cpp
 )
+
+if(TMSEXPRESS_BUILD_GUI)
+    target_sources(${PROJECT_NAME} PRIVATE
+        tms_express/ui/gui/audiowaveform/AudioWaveform.cpp
+        tms_express/ui/gui/audiowaveform/AudioWaveformView.cpp
+        tms_express/ui/gui/controlpanels/ControlPanelView.cpp
+        tms_express/ui/gui/controlpanels/ControlPanelPitchView.cpp
+        tms_express/ui/gui/controlpanels/ControlPanelLpcView.cpp
+        tms_express/ui/gui/controlpanels/ControlPanelPostView.cpp
+        tms_express/ui/gui/MainWindow.cpp
+    )
+endif()
 
 ###############################################################################
 # Project Dependencies ########################################################
 ###############################################################################
 
-find_package(Qt6 COMPONENTS Core Gui Multimedia Widgets REQUIRED)
-find_package(PkgConfig REQUIRED)
+if(TMSEXPRESS_BUILD_GUI)
+    find_package(Qt6 COMPONENTS Core Gui Multimedia Widgets REQUIRED)
 
+    target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+        Qt::Core
+        Qt::Gui
+        Qt::Widgets
+        Qt::Multimedia
+    )
+endif()
+
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(SndFile REQUIRED IMPORTED_TARGET sndfile)
 pkg_check_modules(SampleRate REQUIRED IMPORTED_TARGET samplerate)
 
@@ -79,10 +97,6 @@ target_link_libraries(${PROJECT_NAME}
     PRIVATE
     PkgConfig::SndFile
     PkgConfig::SampleRate
-    Qt::Core
-    Qt::Gui
-    Qt::Widgets
-    Qt::Multimedia
 )
 
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TMS Express 🗣
-TMS Express generates bitstreams for the TMS5220 Voice Synthesis Processor.
+TMS Express generates bitstreams for the TMS5220 Voice Synthesis Processor. It
+also includes a TMS5220 emulator for synthesizing bitstreams as audio files.
 
 ![TMS Express GUI Screenshot](doc/screenshot.png)
 
@@ -21,33 +22,50 @@ Compared to existing encoders, TMS Express has the following advantages:
 
 Linux and Windows (via WSL) users can download the latest TMS Express binary
 from the [Releases](https://github.com/tornupnegatives/TMS-Express/releases)
-tab in GitHub.
+tab in GitHub. Please note that Windows is not officially supported and may not
+function correctly in all cases.
 
 ## macOS & Linux
 
-macOS and Linux users can donwload and install the latest TMS Express binary
-via Homebrew, using the below invocation. macOS binaries are also available
-from the [Releases](https://github.com/tornupnegatives/TMS-Express/releases)
-tab in GitHub.
+Dynamically linked binaries for macOS and Linux may be obtained using the
+Homebrew package manager. Statically linked binaries are provided in the
+[Releases](https://github.com/tornupnegatives/TMS-Express/releases) tab on
+GitHub.
 
 ```shell
 $ brew tap tornupnegatives/tap && brew install tmsexpress
 ```
 
 ## Compile from Source
-### Dependencies
-```shell
-# Ubuntu
-$ sudo apt install cmake libsndfile1-dev libsamplerate0-dev qt6-base-dev qt6-multimedia-dev libgl1-mesa-dev
 
-# macOS
+TMS Express may be compiled as either a command-line (CLI) application or a
+graphical (GUI) application, depending on the user's needs. The CLI version
+has fewer dependencies and will compile on a wider range of systems.
+
+### Installing Dependencies
+
+```shell
+# macOS #######################################################################
+
+$ brew install cmake libsamplerate libsndfile pkg-config
+
+# GUI build
 $ brew install cmake libsamplerate libsndfile pkg-config qt
+
+# Linux (Ubuntu) ##############################################################
+
+# CLI-only build
+$ sudo apt install cmake libsndfile1-dev libsamplerate0-dev pkg-config
+
+# GUI build
+$ sudo apt install cmake libsndfile1-dev libsamplerate0-dev pkg-config \
+  qt6-base-dev qt6-multimedia-dev libgl1-mesa-dev
 ```
 
 ### Compilation
 ```shell
-$ cmake -B build && cd build
-$ cmake --build . -j
+$ cmake -B build # For CLI only, pass -DTMSEXPRESS_BUILD_GUI=OFF
+$ cmake --build build -j
 ```
 
 ## Usage

--- a/tms_express/main.cpp
+++ b/tms_express/main.cpp
@@ -1,25 +1,44 @@
 // Copyright 2023 Joseph Bellahcen <joeclb@icloud.com>
 
+#ifdef TMSEXPRESS_GUI
 #include <QApplication>
+#endif  //  TMSEXPRESS_GUI
 
 #include "ui/cli/CommandLineApp.hpp"
+
+#ifdef TMSEXPRESS_GUI
 #include "ui/gui/MainWindow.hpp"
+#endif  //  TMSEXPRESS_GUI
+
+int runCommandLineApp(int argc, char **argv) {
+    auto cli = tms_express::ui::CommandLineApp();
+    int status = cli.run(argc, argv);
+    return status;
+}
+
+#ifdef TMSEXPRESS_GUI
+int runGraphicalApp(int argc, char **argv) {
+    QApplication app(argc, argv);
+
+    tms_express::ui::MainWindow w;
+    w.show();
+
+    return app.exec();
+}
+#endif  //  TMSEXPRESS_GUI
 
 int main(int argc, char **argv) {
     // If no arguments are passed, launch GUI
     if (argc == 1) {
-        QApplication app(argc, argv);
-
-        tms_express::ui::MainWindow w;
-        w.show();
-
-        return app.exec();
+#ifdef TMSEXPRESS_GUI
+        runGraphicalApp(argc, argv);
+#else
+        runCommandLineApp(argc, argv);
+#endif
     }
 
     // Otherwise, use command-line interface
     if (argc > 1) {
-        auto cli = tms_express::ui::CommandLineApp();
-        int status = cli.run(argc, argv);
-        exit(status);
+        runCommandLineApp(argc, argv);
     }
 }


### PR DESCRIPTION
Per sub-discussion in #53, this PR implements the ability to produce CLI-only or CLI-GUI builds, using CMake flags. To produce a CLI-only build, use the following command:

```shell
$ cmake -B build -DTMSEXPRESS_BUILD_GUI=OFF
$ cmake --build build -j
```