### PR TITLE
Updated unit test workflow to use Dockerfile

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,25 +1,26 @@
 name: Unit Test
+
 on:
   push:
-    branches-ignore:
-      main
+    branches: [ main, develop ]
   pull_request:
+    branches: [ main, develop ]
 
 jobs:
-    unit-test:
-        runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout Repo
-              uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-            - name: Install Dependencies
-              run: sudo apt install cmake wget libsndfile1-dev qt6-base-dev qt6-multimedia-dev libgl1-mesa-dev
-            - name: Configure Build
-              run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DTMSEXPRESS_BUILD_TESTS=ON -DTMSEXPRESS_BUILD_GUI=OFF
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-            - name: Build
-              run: cmake --build ${{github.workspace}}/build --config Debug
+      - name: Build Docker image
+        run: |
+          docker build -f docker/test.dockerfile -t tmsexpress-test .
 
-            - name: Run tests
-              run: cd build && ctest
+      - name: Run tests in container
+        run: |
+          docker run --rm tmsexpress-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::SndFile)
 # The bulk of TMS Express' dependencies may be downloaded and configured using
 # the CMake Package Manager (CPM). An active internet connection is required
 
-include(cmake/CPM.cmake)
+file(
+  DOWNLOAD
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.8/CPM.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
+  EXPECTED_HASH SHA256=78ba32abdf798bc616bab7c73aac32a17bbd7b06ad9e26a6add69de8f3ae4791
+)
+include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
 
 cpmaddpackage(
     CLI11

--- a/docker/test.dockerfile
+++ b/docker/test.dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:jammy
+WORKDIR /workdir
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        cmake \
+        build-essential \
+        git \
+        libsndfile1-dev \
+        qt6-base-dev \
+        qt6-multimedia-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m app && \
+    chown -R app:app /workdir
+USER app
+
+COPY --chown=app:app . .
+
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DTMSEXPRESS_BUILD_TESTS=ON \
+    -DTMSEXPRESS_BUILD_GUI=OFF
+RUN cmake --build ./build --config Debug
+CMD ["cmake", "--build", "./build", "--target", "test"]


### PR DESCRIPTION
The pipeline had gone out of date and was failing. The exact failure had to do with APT failing to fetch `libinput10_1.25.0-1ubuntu3.1_amd64.deb`. Regardless, the pipeline had as a whole fallen out of date anyway. I moved most of the configuration and build process into a Dockerfile, which GitHub Actions will build and run to perform unit testing.

Prior to now, the `cmake` directory held a file containing source code for the CMake Package Manager (CPM). The version of CPM contained in the file is now incompatible with newer versions of CMake. I have updated this project to use the latest CPM version. I also replaced the file with a statement in the project's `CMakeLists.txt` that fetches CPM from the Internet during the build process. This will make it easier to update CPM in the future.